### PR TITLE
Corregido ejemplo en "Databases"

### DIFF
--- a/_posts/07-02-01-Interacting-via-Code.md
+++ b/_posts/07-02-01-Interacting-via-Code.md
@@ -45,7 +45,7 @@ Create a class to place that method in and you have a "Model". Create a simple `
 {% highlight php %}
 <?php
 
-$db = new PDO('mysql:host=localhost;dbname=testdb;charset=utf8', 'username', 'password');
+$db = new PDO('mysql:host=localhost;dbname=testdb;charset=utf8mb4', 'username', 'password');
 
 // Make your model available
 include 'models/FooModel.php';


### PR DESCRIPTION
He corregido un ejemplo para que pudiera seguir la línea del apartado "UTF-8 at the Database level" y utilizase utf8mb4 en lugar de utf8 en las conexiones a MySQL.

Gracias.
