### PR TITLE
Update 01-02-01-Use-the-Current-Stable-Version.md

### DIFF
--- a/_posts/01-02-01-Use-the-Current-Stable-Version.md
+++ b/_posts/01-02-01-Use-the-Current-Stable-Version.md
@@ -1,12 +1,15 @@
 ---
-title: Use la versión estable actual (5.6)
+title: Use la versión estable actual (7.1)
 anchor: use-la-version-estable-actual
 isChild: true
 ---
 
-## Use la versión estable actual (5.6) {#use-la-version-estable-actual}
+## Use la versión estable actual (7.1) {#use-la-version-estable-actual}
 
-Si está dando sus primeros pasos con PHP, asegúrese de usar con la última versión estable (current stable) de [PHP 5.6][php-release]. En los últimos años se ha progresado mucho añadiendo [nuevas y potentes características](#language_highlights) a PHP. Aunque la diferencia entre las versiones 5.2 y 5.6 aparenta ser mínima, en realidad la nueva versión representa _grandes_ mejoras en el sistema. Si estás buscando alguna función en particular o su modo de uso, la documentación oficial en [php.net][php-docs] tendrá la respuesta.
+Si está dando sus primeros pasos con PHP, comienza con la versión estable actual (current stable) de [PHP 7.1][php-release]. PHP 7.1 es muy nuevo y agrega [muchas e interesantes caracteristicas](#language_highlights) en comparación con las antiguas versiones 5.x. El motor ha sido considerablemente reescrito y en consecuencia PHP es ahora más rápido que las versiones antiguas.
+
+Usted se encontrará en el futuro cercano con que la versión de PHP 5.x es usada, la ultima versión 5.x es la 5.6. Esta no es una mala opción pero deberias intentar actualizar a la ultima versión estable lo más rápido posible, PHP 5.6 no recibirá actualizaciones de seguridad luego del 2018. Actualizar es realmente fácil y no hay muchos [problemas de retrocompatibilidad que rompan el código][php71-bc]. Si no estas seguro sobre la versión de una función o caracteristica revisá la documentación de PHP en el sitio web [php.net][php-docs].
 
 [php-release]: http://www.php.net/downloads.php
 [php-docs]: http://www.php.net/manual/es/
+[php71-bc]: http://php.net/manual/migration71.incompatible.php


### PR DESCRIPTION
Se actualiza el post "01-02-01-Use-the-Current-Stable-Version.md" ahora no se recomienda usar PHP 5.x sino PHP 7.1.